### PR TITLE
Remove empty format precision specifier

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -36,17 +36,17 @@ fn main() {
     let char_rom_start = 0x10 + buf[4] as u16 * 0x4000;
     let char_rom_end = char_rom_start + buf[5] as u16 * 0x2000;
 
-    println!("{:.?} {:.?}", char_rom_start, char_rom_end);
+    println!("{:?} {:?}", char_rom_start, char_rom_end);
 
     create_character_graphic(&buf[char_rom_start as usize..char_rom_end as usize]);
 }
 
 fn create_character_graphic(char_rom: &[u8]) {
     let sprite_num: u32 = (char_rom.len() >> 4) as u32;
-    println!("Sprite Num => {:.?}", sprite_num);
+    println!("Sprite Num => {:?}", sprite_num);
     let h_num: u32 = 8;
     let w_num: u32 = -(-(sprite_num as i32) / h_num as i32) as u32;
-    println!("{:.?}, {:.?}", w_num, h_num);
+    println!("{:?}, {:?}", w_num, h_num);
 
     const SPRITE_DSIZE: u32 = 0x10;
     const SPRITE_WSIZE: u32 = 0x8;


### PR DESCRIPTION
A format precision specifier consisting of a dot and no number actually does nothing and has no specified meaning. Currently this is silently ignored, but it may turn into a warning or error.

See https://github.com/rust-lang/rust/issues/131159 and https://github.com/rust-lang/rust/pull/136638

Please leave a comment there if you have any opinion about this. If you remember why this was written this way that could help improve the diagnostics rustc gives.